### PR TITLE
fix: correctly overload jest spyOn object when no prop is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ mock.extend(jest);
 
 jest.spy("src/example");
 
-const spied = require("src/example");
+const example = require("src/example");
 
-jest.isMockProp(spied, "testing"); // true
-jest.isMockMethod(spied.nested.test); // true
-jest.isMockProp(spied.nested, "testing"); // true
+// Check module object properties
+jest.isMockProp(example, "testing"); // true
+console.log(example.testing); // 123
+
+// Respy on module object to get mockable
+jest.spyOn(example).testing.mockValueOnce("789");
+console.log(example.testing); // 789
+console.log(example.testing); // 123
+
+// Check module nested object properties
+jest.isMockMethod(example.nested.test); // true
+jest.isMockProp(example.nested, "testing"); // true
 ```
 
 It keeps the same structure of the module but replaces all functions and properties with jest mocks.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
-import { CreateSpyOn, ExtendJest, SpyOn } from "../typings/globals";
+import { SpyOnProp } from "jest-mock-props";
+import { CreateSpyOn, ExtendJest, MockObject, SpyOn } from "../typings/globals";
 import { mapObject } from "./utils";
 
+const SpyMockProp = Symbol("__mock__");
+
+type JestSpyInstance = {
+  spyOn: typeof jest.spyOn;
+  spyOnProp: SpyOnProp;
+} & Partial<typeof jest>;
+
 export function spyOnProp<T>(
-  jestInstance: typeof jest,
+  jestInstance: JestSpyInstance,
   object: T,
   propName: keyof T,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,7 +22,6 @@ export function spyOnProp<T>(
     return jestInstance.spyOn(object, propName);
   }
   if (propType === "object" && propValue !== null) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return spyOnObject(jestInstance, propValue);
   }
   try {
@@ -26,14 +33,28 @@ export function spyOnProp<T>(
   }
 }
 
-export function spyOnObject<T>(jestInstance: typeof jest, o?: T) {
-  if (o === undefined || o === null) return o;
+export function isMockObject<T>(
+  o?: T,
+): o is T & { [SpyMockProp]: MockObject<T> } {
+  return !!o && Object.prototype.hasOwnProperty.call(o, SpyMockProp);
+}
+
+export function spyOnObject<T>(
+  jestInstance: JestSpyInstance,
+  o: T,
+): MockObject<T> {
+  if (isMockObject(o)) return o[SpyMockProp];
   return mapObject(o, ([k]) => spyOnProp<T>(jestInstance, o, k));
 }
 
-export function spyOnModule<T>(jestInstance: typeof jest, moduleName: string) {
-  const actualModule = jestInstance.requireActual<T>(moduleName);
-  return spyOnObject<T>(jestInstance, actualModule);
+export function spyOnModule<T>(
+  jestInstance: typeof jest,
+  moduleName: string,
+): T & { [SpyMockProp]?: MockObject<T> } {
+  const actual = jestInstance.requireActual<T>(moduleName);
+  return Object.assign(actual, {
+    [SpyMockProp]: spyOnObject<T>(jestInstance, actual),
+  });
 }
 
 function bind(jestInstance: typeof jest) {
@@ -43,7 +64,12 @@ function bind(jestInstance: typeof jest) {
   const spy: SpyOn = (moduleName: string) => {
     jest.mock(moduleName, () => createSpyFromModule(moduleName));
   };
-  return { createSpyFromModule, spy };
+  return {
+    createSpyFromModule,
+    genSpyFromModule: createSpyFromModule,
+    spy,
+    spyOnObject: <T>(o: T) => spyOnObject(jestInstance, o),
+  };
 }
 
 export const extend: ExtendJest = (jestInstance) => {
@@ -57,10 +83,20 @@ export const extend: ExtendJest = (jestInstance) => {
         "spy on non function module properties.",
     );
   }
-  const bound = bind(jestInstance);
-  Object.assign(jestInstance, {
-    ...bound,
-    genSpyFromModule: bound.createSpyFromModule,
+  const spyOn = jestInstance.spyOn;
+  const spyOnProp = jestInstance.spyOnProp;
+  Object.assign(jestInstance, bind(jestInstance), {
+    isMockObject,
+    spyOn: <T>(
+      object: T,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      propName: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      accessType: any,
+    ) => {
+      if (!propName) return spyOnObject({ spyOn, spyOnProp }, object);
+      return spyOn(object, propName, accessType);
+    },
   });
 };
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -2,6 +2,11 @@
 
 exports[`spies on object nested properties 1`] = `
 Object {
+  "list": Array [
+    Object {
+      "propX": 2,
+    },
+  ],
   "nested": Object {
     "propA": null,
     "propB": true,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,24 +1,39 @@
 import "jest-mock-props";
-import { extend, spyOnObject } from "src/index";
+import * as utils from "src/utils";
+import { extend, isMockObject, spyOnModule, spyOnObject } from "src/index";
+
 extend(jest);
+jest.spyOn(utils, "mapObject");
 afterEach(jest.clearAllMocks);
+
+it("reuses existing spy when there is one", () => {
+  const moduleName = "tests/mocks/hello";
+  expect(jest.createSpyFromModule(moduleName)).toBe(
+    spyOnModule(jest, moduleName),
+  );
+  expect(utils.mapObject).toBeCalledTimes(1);
+});
 
 it("spies on methods called", () => {
   jest.spy("tests/mocks/hello");
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { say, shout } = require("./mocks/hello");
+  const hello = require("./mocks/hello");
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const sayHello = require("./mocks/index").default;
 
+  expect(isMockObject(hello)).toBe(true);
+  expect(hello.CALL).toEqual("Hello");
+  jest.spyOnObject(hello)?.CALL.mockValueOnce("Hi");
+  expect(sayHello("You")).toEqual("HI YOU!");
   expect(sayHello("You")).toEqual("HELLO YOU!");
-  expect(say).toHaveBeenCalledTimes(1);
-  expect(shout).toHaveBeenCalledTimes(1);
-  ((say as unknown) as jest.SpyInstance).mockImplementationOnce(
+  expect(hello.say).toHaveBeenCalledTimes(2);
+  expect(hello.shout).toHaveBeenCalledTimes(2);
+  ((hello.say as unknown) as jest.SpyInstance).mockImplementationOnce(
     () => "something",
   );
   expect(sayHello("Who")).toEqual("SOMETHING!");
-  ((shout as unknown) as jest.SpyInstance).mockImplementationOnce((s: string) =>
-    s.toLocaleLowerCase(),
+  ((hello.shout as unknown) as jest.SpyInstance).mockImplementationOnce(
+    (s: string) => s.toLocaleLowerCase(),
   );
   expect(sayHello("Gru")).toEqual("hello gru");
 });
@@ -45,6 +60,7 @@ it("spies on object nested properties", () => {
   expect(jest.isMockProp(obj.nested, "propA")).toBe(true);
   expect(jest.isMockProp(obj.nested, "propB")).toBe(true);
 
+  // @ts-expect-error allow assignment
   spied.nested.propA.mockValueOnce(1);
   expect(obj.nested.propA).toEqual(1);
   expect(obj.nested.propA).toBeNull();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import "jest-mock-props";
 import * as utils from "src/utils";
-import { extend, isMockObject, spyOnModule, spyOnObject } from "src/index";
+import { extend, isMockObject, spyOnModule } from "src/index";
 
 extend(jest);
 jest.spyOn(utils, "mapObject");
@@ -49,16 +49,22 @@ it("spies on object nested properties", () => {
       propA: null,
       propB: true,
     },
+    list: [{ propX: 2 }],
   };
-  const spied = spyOnObject(jest, obj);
+  const spied = jest.spyOn(obj);
   if (!spied) fail("Expect spied to be defined and not null");
   expect(obj).toMatchSnapshot();
   expect(jest.isMockProp(obj, "prop1")).toBe(true);
   expect(jest.isMockProp(obj, "prop2")).toBe(true);
   expect(jest.isMockFunction(obj.propFn)).toBe(true);
+  expect(jest.isMockProp(obj, "list")).toBe(true);
   expect(jest.isMockProp(obj, "nested")).toBe(false);
   expect(jest.isMockProp(obj.nested, "propA")).toBe(true);
   expect(jest.isMockProp(obj.nested, "propB")).toBe(true);
+
+  spied.list.mockValueOnce([]);
+  expect(obj.list).toHaveLength(0);
+  expect(obj.list).toHaveLength(1);
 
   // @ts-expect-error allow assignment
   spied.nested.propA.mockValueOnce(1);

--- a/tests/mocks/hello.ts
+++ b/tests/mocks/hello.ts
@@ -1,3 +1,5 @@
+export const CALL = "Hello";
+
 export function say(what: string, who: string): string {
   return `${what} ${who}`;
 }

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -1,5 +1,5 @@
-import { say, shout } from "./hello";
+import { CALL, say, shout } from "./hello";
 
 export default function sayHello(who: string): string {
-  return shout(say("Hello", who));
+  return shout(say(CALL, who));
 }

--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -1,4 +1,6 @@
-import "jest-mock-props";
+import { MockProp } from "jest-mock-props";
+
+declare const SpyMockProp: unique symbol;
 
 export type Entry<ObjectType> = {
   [K in keyof ObjectType]: [K, ObjectType[K]];
@@ -16,20 +18,50 @@ export type MapFn<ObjectType, ResultType> = (
   array: Entries<ObjectType>,
 ) => Mapped<ObjectType, ResultType>[keyof ObjectType];
 
-export type Mock<ObjectType> = {
-  [K in keyof ObjectType]: Mock<ObjectType[K]>;
-};
+type SimplePropertyNames<T> = Exclude<
+  jest.NonFunctionPropertyNames<T>,
+  ObjectPropertyNames<T>
+>;
 
-export type SpyOn = (moduleName: string) => void;
+type ObjectPropertyNames<T> = {
+  [K in keyof T]: T[K] extends Record<keyof unknown, unknown> ? K : never;
+}[keyof T] &
+  string;
+
+export type MockObject<T> = {
+  [K in SimplePropertyNames<T>]: MockProp<T>;
+} &
+  {
+    [K in ObjectPropertyNames<T>]: MockObject<T[K]>;
+  } &
+  {
+    [K in jest.FunctionPropertyNames<T>]: ReturnType<typeof jest["spyOn"]>;
+  } &
+  {
+    [K in jest.ConstructorPropertyNames<T>]: ReturnType<typeof jest["spyOn"]>;
+  };
+
+type A = jest.NonFunctionPropertyNames<{ a: 2; c: { b: 1 } }>;
+
+export type IsMockObject = <T>(
+  o?: T,
+) => o is T & { [SpyMockProp]?: MockObject<T> };
+
 export type CreateSpyOn = <T = unknown, U = T>(
   moduleName: string,
 ) => Mapped<T, U> | undefined;
 
+export type SpyOn = (moduleName: string) => void;
+export type SpyOnObject = <T = unknown>(o?: T) => MockObject<T> | undefined;
+
 declare global {
   namespace jest {
+    const isMockObject: IsMockObject;
     const createSpyFromModule: CreateSpyOn;
     const genSpyFromModule: CreateSpyOn;
     const spy: SpyOn;
+    function spyOn<T>(object: T): Mock<T>;
+    const spyOnObject: SpyOnObject;
   }
 }
 


### PR DESCRIPTION
# Description

- Track mock objects
- Export `isMockObject`
- Fix mock object property override
- Export `spyOnObject`

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

N/A
